### PR TITLE
fix: failed to run app after ll-cli reviced SIGINT

### DIFF
--- a/libs/ocppi/src/ocppi/cli/Process.cpp
+++ b/libs/ocppi/src/ocppi/cli/Process.cpp
@@ -66,8 +66,19 @@ int runProcess(const std::string &binaryPath,
                 output.append(buffer.data(), readCount);
         }
 
-        if (::wait(&ret) == -1) {
-                throw std::system_error(errno, std::generic_category(), "wait");
+
+        int interruptTimes = 0;
+        while (true) {
+            if (::wait(&ret) == -1) {
+                if (errno == EINTR) {
+                    interruptTimes < 2 ? ++interruptTimes : kill(childId, SIGKILL);
+                    continue; 
+                } 
+                
+                throw std::system_error(errno, std::generic_category(), "wait: " + std::to_string(errno));
+            } else {
+                break;
+            }
         }
 
         ::close(pipes[0]);
@@ -98,8 +109,18 @@ int runProcess(const std::string &binaryPath,
                                         "execvp");
         }
 
-        if (::wait(&ret) == -1) {
-                throw std::system_error(errno, std::generic_category(), "wait");
+        int interruptTimes = 0;
+        while (true) {
+            if (::wait(&ret) == -1) {
+                if (errno == EINTR) {
+                    interruptTimes < 2 ? ++interruptTimes : kill(childId, SIGKILL);
+                    continue; 
+                } 
+                
+                throw std::system_error(errno, std::generic_category(), "wait: " + std::to_string(errno));
+            } else {
+                break;
+            }
         }
 
         return ret;


### PR DESCRIPTION
    * If the errno which returns from ::wait in ll-cli
      is EINTR, wait child more times. And if interrupt
      by SIGINT one more time, kill child immediately.
    * If the pid which in container json  is not exists,
      remove the json.

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added container cleanup functionality to ensure the validity of container statuses.
  
- **Improvements**
  - Enhanced JSON formatting for better readability in the listing function.
  - Improved reliability of process execution by managing interruptions and limiting retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->