### PR TITLE
chore: bump version to 1.5.7-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+linglong (1.5.7-1) unstable; urgency=medium
+
+  * fix: failed to run app after ll-cli received SIGINT
+  * fix: Canceling a task causes the package manager to crash.
+  * fix: remove task after installation
+  * fix: ll-cli install return error errcode
+  * feat: support for installing from uab
+  * fix: container env error when environment variables have multiple values
+  * fix: ll-builder convert appimage error when use url
+  * fix: update bash completion
+
+ -- dengbo <dengbo@deepin.org>  Mon, 01 Jul 2024 15:32:20 +0800
+
 linglong (1.5.6-1) unstable; urgency=medium
 
   * fix: layer size error when export layer repeatedly


### PR DESCRIPTION
release 1.5.7-1

Log: bump version to 1.5.7-1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app execution.
  - Enhanced task handling and package installation.
  - Fixed error handling and environment variable issues.
  - Corrected bash completion.

- **New Features**
  - Added support for installing from `uab`.

- **Improvements**
  - Addressed issues with `ll-builder` converting appimages from URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->