### PR TITLE
feat: recheck minified layer after uninstalling or installing layer

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -708,9 +708,9 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
     if (!result) {
         qWarning() << "remove" << ref->toString() << result.error().message();
     }
-    result = this->repo.importLayerDir(binaryOutputLayerDir);
-    if (!result) {
-        return LINGLONG_ERR(result);
+    auto localLayer = this->repo.importLayerDir(binaryOutputLayerDir);
+    if (!localLayer) {
+        return LINGLONG_ERR(localLayer);
     }
 
     package::LayerDir developOutputLayerDir = developOutput.absoluteFilePath("..");
@@ -718,9 +718,9 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
     if (!result) {
         qWarning() << "remove" << ref->toString() << result.error().message();
     }
-    result = this->repo.importLayerDir(developOutputLayerDir);
-    if (!result) {
-        return LINGLONG_ERR(result);
+    localLayer = this->repo.importLayerDir(developOutputLayerDir);
+    if (!localLayer) {
+        return LINGLONG_ERR(localLayer);
     }
 
     printMessage("Successfully build " + this->project.package.id);

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -55,6 +55,8 @@ private:
     static void filterPackageInfosFromType(std::vector<api::types::v1::PackageInfoV2> &list,
                                            const QString &type) noexcept;
     void updateAM() noexcept;
+    [[nodiscard]] utils::error::Result<package::LayerDir> getDependLayerDir(
+      const package::Reference &appRef, const package::Reference &ref) const noexcept;
 
 public:
     int run(std::map<std::string, docopt::value> &args);
@@ -74,7 +76,7 @@ public:
     void cancelCurrentTask();
 
 private Q_SLOTS:
-    int installFromFile(const QFileInfo& fileInfo);
+    int installFromFile(const QFileInfo &fileInfo);
     void processDownloadStatus(const QString &recTaskID,
                                const QString &percentage,
                                const QString &message,

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -49,8 +49,8 @@ public:
     api::types::v1::RepoConfig getConfig() const noexcept;
     utils::error::Result<void> setConfig(const api::types::v1::RepoConfig &cfg) noexcept;
 
-    utils::error::Result<void> importLayerDir(const package::LayerDir &dir,
-                                              const QString &subRef = "") noexcept;
+    utils::error::Result<package::LayerDir> importLayerDir(const package::LayerDir &dir,
+                                                           const QString &subRef = "") noexcept;
 
     utils::error::Result<package::LayerDir> getLayerDir(const package::Reference &ref,
                                                         bool develop = false,


### PR DESCRIPTION
support for looking up minified depends in `run` process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to retrieve layer directories for dependencies, enhancing dependency management.
  
- **Improvements**
  - Enhanced logic for importing and managing layer directories.
  - Improved dependency handling in installation processes.
  
- **Bug Fixes**
  - Added checks for task cancellation to prevent incomplete operations.
  
- **Refactor**
  - Updated method signatures and internal logic for better code maintainability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->