### PR TITLE
fix: builder create return error

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -198,7 +198,17 @@ int main(int argc, char **argv)
         }
 
         QDir projectDir = QDir::current().absoluteFilePath(projectName);
-        projectDir.mkpath(".");
+        if (projectDir.exists()) {
+            qCritical() << projectName << "project dir already exists";
+            return -1;
+        }
+
+        auto ret = projectDir.mkpath(".");
+        if (!ret) {
+            qCritical() << "create project dir failed";
+            return -1;
+        }
+
         auto configFilePath = projectDir.absoluteFilePath("linglong.yaml");
         auto templateFilePath = LINGLONG_DATA_DIR "/builder/templates/example.yaml";
 


### PR DESCRIPTION
when project dir have exist or mkpath error, we must return error code

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a check to ensure the project directory exists before creating it.
  - Added error handling for scenarios where the directory already exists or fails to be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->