### PR TITLE
fix: check if the ref exists in the local repo before deleting it

### DIFF
--- a/libs/utils/src/linglong/utils/error/error.h
+++ b/libs/utils/src/linglong/utils/error/error.h
@@ -149,10 +149,12 @@ public:
                     const QString &msg,
                     GError const *const e) -> Error
     {
-        if (e == nullptr) {
-            return Err(file, line, trace_msg, msg + ": unknown glib error");
+        QString new_msg = msg;
+        if (e != nullptr) {
+            new_msg.append(
+              QString{ " error code:%1, message:%2" }.arg(QString::number(e->code), e->message));
         }
-        return Err(file, line, trace_msg, msg + ": " + e->message, e->code);
+        return Err(file, line, trace_msg, new_msg);
     }
 
     static auto Err(const char *file,


### PR DESCRIPTION
currently, ostree_repo_set_ref_immediate will ignore error 'ENOENT' when unlinking ref using unlinkat and doesn't report any errors.

so we should resolve ref locally before deleting it.

resolve: https://github.com/OpenAtomFoundation/linglong/issues/564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for reference resolution in repository functions.
  - Enhanced directory creation and file copying logic to prevent operational errors.

- **New Features**
  - Introduced local-only reference resolution in repository management.

- **Refactor**
  - Updated error message handling in `Error` class to provide more detailed messages when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->