### PR TITLE
fix: example build error in uos20 arm arch

### DIFF
--- a/misc/share/linglong/builder/templates/example.yaml
+++ b/misc/share/linglong/builder/templates/example.yaml
@@ -10,7 +10,7 @@ package:
 
 command: [echo, -e, hello world] #the commands that your application need to run.
 
-base: org.deepin.foundation/23.0.0 #set the base environment, this can be changed.
+base: org.deepin.foundation/20.0.0 #set the base environment, this can be changed.
 
 #set the runtime environment if you need, a example of setting deepin runtime is as follows.
 #runtime:


### PR DESCRIPTION
org.deepin.foundation has no 23.0.0 arm architecture, use 20.0.0

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the base environment version in the builder templates from `23.0.0` to `20.0.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->