### PR TITLE
build: make ll-box statically linked and enable uab build on deepin 23 and uos 20

### DIFF
--- a/apps/ll-box/CMakeLists.txt
+++ b/apps/ll-box/CMakeLists.txt
@@ -2,7 +2,16 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-pkg_check_modules(SECCOMP REQUIRED IMPORTED_TARGET libseccomp)
+set(BOX_BIN_NAME "ll-box")
+
+if(${STATIC_BOX})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+  message(STATUS "build ll-box statically")
+  set(BOX_BIN_NAME "ll-box-static")
+  add_link_options(-static -static-libgcc -static-libstdc++)
+endif()
+
+pkg_search_module(SECCOMP REQUIRED IMPORTED_TARGET libseccomp)
 
 pfl_add_executable(
   SOURCES
@@ -36,7 +45,7 @@ pfl_add_executable(
   src/util/semaphore.h
   src/util/util.h
   OUTPUT_NAME
-  ll-box
+  ${BOX_BIN_NAME}
   LINK_LIBRARIES
   PUBLIC
   nlohmann_json::nlohmann_json
@@ -45,3 +54,15 @@ pfl_add_executable(
   COMPILE_OPTIONS
   PRIVATE
   -DJSON_USE_IMPLICIT_CONVERSIONS=0)
+
+if(${STATIC_BOX})
+  target_link_libraries(PkgConfig::SECCOMP
+                        INTERFACE ${SECCOMP_STATIC_LIBRARIES})
+
+  include(GNUInstallDirs)
+  file(CREATE_LINK ${CMAKE_INSTALL_FULL_BINDIR}/ll-box-static
+       ${CMAKE_CURRENT_BINARY_DIR}/ll-box SYMBOLIC)
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ll-box
+          DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+endif()

--- a/apps/uab/header/CMakeLists.txt
+++ b/apps/uab/header/CMakeLists.txt
@@ -3,28 +3,39 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-find_library(FOUND_erofsfuse_STATIC "erofsfuse")
 
+# TODO: if erofsfuse and libdeflate provides .pc file or config.cmake, change it
+# to pkg_search_modules/find_package
+
+find_library(FOUND_erofsfuse_STATIC "erofsfuse")
 if("${FOUND_erofsfuse_STATIC}" STREQUAL "")
-  message(SEND_ERROR "liberofsfuse.a not fount, skip uab-header")
+  message(FATAL_ERROR "liberofsfuse.a not fount")
 endif()
 
-get_filename_component(ABS_FILE ${FOUND_erofsfuse_STATIC} ABSOLUTE)
+get_filename_component(EROFSFUSE_ABS_FILE ${FOUND_erofsfuse_STATIC} ABSOLUTE)
 message(STATUS "found liberofsfuse.a: ${ABS_FILE}")
 
-find_package(libdeflate REQUIRED COMPONENTS libdeflate_static)
+find_library(FOUND_libdeflate_STATIC "deflate")
+if("${FOUND_libdeflate_STATIC}" STREQUAL "")
+  message(FATAL_ERROR "libdeflate.a not fount")
+endif()
+
+get_filename_component(LIBDEFLATE_ABS_FILE ${FOUND_libdeflate_STATIC} ABSOLUTE)
+message(STATUS "found libdeflate.a: ${LIBDEFLATE_ABS_FILE}")
 
 pkg_search_module(elf_static REQUIRED IMPORTED_TARGET libelf)
 pkg_search_module(lz4 REQUIRED IMPORTED_TARGET liblz4)
 pkg_search_module(lzma REQUIRED IMPORTED_TARGET liblzma)
 pkg_search_module(ZLIB REQUIRED IMPORTED_TARGET zlib)
+pkg_search_module(ZSTD REQUIRED IMPORTED_TARGET libzstd)
 pkg_search_module(FUSE REQUIRED IMPORTED_TARGET fuse)
 pkg_search_module(SELINUX REQUIRED IMPORTED_TARGET libselinux)
-pkg_search_module(PCRE2-8 REQUIRED IMPORTED_TARGET libpcre2-8)
 pkg_search_module(CRYPTO REQUIRED IMPORTED_TARGET libcrypto)
-pkg_search_module(ZSTD REQUIRED IMPORTED_TARGET libzstd)
 
 add_link_options(-static -static-libgcc -static-libstdc++)
+
+target_link_libraries(PkgConfig::SELINUX INTERFACE ${SELINUX_STATIC_LIBRARIES})
+target_link_libraries(PkgConfig::FUSE INTERFACE ${FUSE_STATIC_LIBRARIES})
 
 pfl_add_executable(
   DISABLE_INSTALL
@@ -34,19 +45,19 @@ pfl_add_executable(
   uab-header
   LINK_LIBRARIES
   PRIVATE
-  ${ABS_FILE}
   linglong::api
+  nlohmann_json::nlohmann_json
+  PkgConfig::SELINUX
   PkgConfig::elf_static
   PkgConfig::lz4
   PkgConfig::lzma
   PkgConfig::ZLIB
-  PkgConfig::FUSE
-  PkgConfig::SELINUX
-  PkgConfig::PCRE2-8
   PkgConfig::CRYPTO
   PkgConfig::ZSTD
-  libdeflate::libdeflate_static
-  nlohmann_json::nlohmann_json)
+  PkgConfig::FUSE
+  ${EROFSFUSE_ABS_FILE}
+  ${LIBDEFLATE_ABS_FILE}
+  stdc++fs)
 
 include(GNUInstallDirs)
 

--- a/apps/uab/header/src/main.cpp
+++ b/apps/uab/header/src/main.cpp
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <cstring>
 #include <filesystem>
+#include <iomanip>
 #include <iostream>
 #include <optional>
 
@@ -280,7 +281,7 @@ std::string calculateDigest(int fd, std::size_t bundleOffset, std::size_t bundle
     };
     auto ctx =
       std::unique_ptr<EVP_MD_CTX, decltype(ctxDeleter)>(EVP_MD_CTX_new(), std::move(ctxDeleter));
-    if (EVP_DigestInit_ex2(ctx.get(), EVP_sha256(), nullptr) == 0) {
+    if (EVP_DigestInit_ex(ctx.get(), EVP_sha256(), nullptr) == 0) {
         std::cerr << "init digest context error" << std::endl;
         return {};
     }

--- a/apps/uab/loader/src/main.cpp
+++ b/apps/uab/loader/src/main.cpp
@@ -475,7 +475,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
     std::vector<std::string> command;
     try {
         auto content = nlohmann::json::parse(appStream);
-        if (content.contains("command")) {
+        if (content.find("command") != content.end()) {
             command = content["command"].get<std::vector<std::string>>();
         }
     } catch (nlohmann::json::parse_error &e) {

--- a/debian/linglong-box.install
+++ b/debian/linglong-box.install
@@ -1,1 +1,2 @@
+/usr/bin/ll-box-static
 /usr/bin/ll-box

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,13 @@ include /usr/share/dpkg/pkg-info.mk
 OS=$(shell awk '/^NAME=/' /etc/os-release | sed 's/NAME=//' | sed 's/\"//g' | tr '[:upper:]' '[:lower:]')
 ARCH=$(shell dpkg-architecture -qDEB_HOST_ARCH | cut -c1-3)
 VERSION=$(shell awk '/VERSION=/' /etc/os-release | sed 's/VERSION=//' | sed 's/\"//g' | sed 's/[.]0/./')
+ENABLE_UAB_SUPPORT=FALSE
+
+ifeq ($(OS) $(VERSION), deepin 23)
+	ENABLE_UAB_SUPPORT=TRUE
+else ifeq ($(OS) $(VERSION), uos 20)
+	ENABLE_UAB_SUPPORT=TRUE
+endif
 
 %:
 	dh $@ --buildsystem=cmake
@@ -14,8 +21,9 @@ override_dh_auto_install:
 
 EXTRA_OPTION = -DCPM_LOCAL_PACKAGES_ONLY=ON -DLINGLONG_VERSION=$(DEB_VERSION_UPSTREAM)
 
-ifeq ($(OS) $(VERSION), deepin 23)
-	EXTRA_OPTION += -DENABLE_UAB=ON
+ifeq ($(ENABLE_UAB_SUPPORT), TRUE)
+
+	EXTRA_OPTION += -DENABLE_UAB=ON -DSTATIC_BOX=ON
 
 override_dh_auto_install:
 	dh_auto_install


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added static linking options and renamed output executable to `ll-box-static`.
  - Introduced `ENABLE_UAB_SUPPORT` for conditional UAB support based on OS and version.

- **Enhancements**
  - Improved library searching and linking for SECCOMP, SELINUX, and FUSE.
  - Updated error handling logic in SHA-256 digest context initialization.
  - Added new library requirements for improved compatibility and static builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->