### PR TITLE
fix: Error when running ldconfig

### DIFF
--- a/libs/linglong/src/linglong/runtime/container_builder.cpp
+++ b/libs/linglong/src/linglong/runtime/container_builder.cpp
@@ -330,7 +330,8 @@ auto fixMount(ocppi::runtime::config::types::Config config) noexcept
     }
 
     using MountType = std::remove_reference_t<decltype(mounts)>::value_type;
-    auto rootBinds = originalRoot.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
+    auto rootBinds =
+      originalRoot.entryInfoList(QDir::Dirs | QDir::Files | QDir::System | QDir::NoDotAndDotDot);
     auto pos = mounts.begin();
     for (const auto &bind : rootBinds) {
         auto mountPoint = MountType{
@@ -363,7 +364,7 @@ auto fixMount(ocppi::runtime::config::types::Config config) noexcept
 
         auto dir = QDir{ tmpfs };
         for (const auto &rootDest :
-             dir.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot)) {
+             dir.entryInfoList(QDir::Dirs | QDir::Files | QDir::System | QDir::NoDotAndDotDot)) {
             auto rootDestPath = rootDest.absoluteFilePath();
             auto destination = rootDestPath.mid(originalRoot.absolutePath().size());
             auto mountPoint = MountType{

--- a/misc/lib/linglong/container/config.json
+++ b/misc/lib/linglong/container/config.json
@@ -28,19 +28,16 @@
             {
                 "path": "/bin/bash",
                 "args": [
-                    "/bin/bash",
                     "-c",
-                    "( /sbin/ldconfig || true ) && cat /etc/ld.so.cache~ > /etc/ld.so.cache"
+                    "mkdir -p /run/linglong/etc && /sbin/ldconfig -C /run/linglong/etc/ld.so.cache"
                 ]
             }
         ]
     },
     "mounts": [],
     "process": {
-        "env": [],
+        "env": ["LINGLONG_LD_SO_CACHE=/run/linglong/etc/ld.so.cache"],
         "cwd": "/",
-        "args": [
-            "bash"
-        ]
+        "args": ["bash"]
     }
 }


### PR DESCRIPTION
ldconfig会在生成缓存内容后,移动临时文件到缓存文件,所以不应该将临时文件做成挂载点
现在将缓存文件做成软链接, 软链接指向可读写的位置,可避免 /etc 只读的情况

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Improved handling of shared library cache files by using symlinks, which enhances system compatibility and consistency.

- **Bug Fixes**
  - Updated mount options to ensure more reliable access to shared libraries within containers.

- **Chores**
  - Streamlined configuration process for shared library cache, reducing complexity and potential errors.
  - Added an environment variable for better management of shared library cache paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->