### PR TITLE
feat: ll-build appimage convert support export uab or layer

### DIFF
--- a/docs/pages/en/guide/ll-builder/convert.md
+++ b/docs/pages/en/guide/ll-builder/convert.md
@@ -37,6 +37,8 @@ Options:
   -n, --name <app description>               the description the app
   -V, --version <app version>                the version of the app
   -d, --description <app description>        detailed description of the app
+  --icon <path>                              uab icon (optional)
+  -l, --layer                                export layer file
   -o, --output <script name>                 not required option, it will
                                              generate linglong.yaml and
                                              script,you can modify
@@ -46,17 +48,20 @@ Options:
                                              .layer(.uab)
 
 Arguments:
-  convert                                    convert app with
-                                             (deb,AppImage(appimage)) format to
-                                             linglong format, you can generate
-                                             convert config file by use -o
-                                             option
+  convert                                    convert app with (deb,AppImage(appimage)) format to
+                                             linglong format, the default format is uab
+                                             if you want to export a layer file
+                                             you can use the --layer option
+                                             you can generate convert config file by use -o option
 ```
 
 The `ll-builder convert` command will generate a directory according to specified app name( `--name` option), it will as a root directory of the linglong project, where the `linglong.yaml` file is located. and it supports two convert methods:
 
 1. you can use `--file` option to convert to linglong pkg according to specified appimage file;
 2. you can use `--url` and `--hash` option to convert to linglong pkg according to specified appimage url and hash value;
+3. you can use `--layer` option to export `.layer`, or it will export `.uab` default.
+
+`Tips: When the linglong version is greater than 1.5.7, the default convert package format is `.uab`, if you want to export a `.layer` file, you need to add the --layer option.`
 
 you can use `--output` option to generate config file( `linglong.yaml` ) of linglong project and a script of build linglong `.layer`(`.uab`)
 then you can execute script file to generate after you modify the `linglong.yaml` file. if you do not specify this option, it will export linglong `.layer` or linglong `.uab` directly.
@@ -69,8 +74,30 @@ Specify the relevant parameters of the linglong package you want to convert, you
 ll-builder convert --url "https://github.com/makebrainwaves/BrainWaves/releases/download/v0.15.1/BrainWaves-0.15.1.AppImage" --hash "04fcfb9ccf5c0437cd3007922fdd7cd1d0a73883fd28e364b79661dbd25a4093" --name "io.github.brainwaves" --id "io.github.brainwaves" --version "0.15.1" --description "io.github.brainwaves" -v
 ```
 
-Take converting BrainWaves-0.15.1.AppImage into linglong.layer through `--file` as an example, the main steps as follows:
+Take converting BrainWaves-0.15.1.AppImage into `.uab` through `--file` as an example, the main steps as follows:
 
 ```bash
-ll-builder convert -f ~/Downloads/BrainWaves-0.15.1.AppImage --name "io.github.brainwaves" --id "io.github.brainwaves" --version "0.15.1" --description "io.github.brainwaves" -v
+ll-builder convert -f ~/Downloads/BrainWaves-0.15.1.AppImage --name "io.github.brainwaves" --id "io.github.brainwaves" --version "0.15.1" --description "io.github.brainwaves"
 ```
+
+The converted directory structure is as follows:
+```text
+io.github.brainwaves
+└── io.github.brainwaves_x86_64_0.15.1.0_main.uab
+```
+
+Take converting BrainWaves-0.15.1.AppImage into `.layer` through `--file` as an example, the main steps as follows:
+
+```bash
+ll-builder convert -f ~/Downloads/BrainWaves-0.15.1.AppImage --name "io.github.brainwaves" --id "io.github.brainwaves" --version "0.15.1" --description "io.github.brainwaves" --layer
+```
+
+The converted directory structure is as follows:
+```text
+io.github.brainwaves
+├── io.github.brainwaves_0.15.1.0_x86_64_binary.layer
+└── io.github.brainwaves_0.15.1.0_x86_64_develop.layer
+```
+
+`.uab` or `.layer` file verification
+The exported `.uab` or `.layer` needs to be installed and verified. install the layer file and run the application, you can refer to: [Install the application](../ll-cli/install.md)

--- a/docs/pages/en/guide/ll-cli/install.md
+++ b/docs/pages/en/guide/ll-cli/install.md
@@ -58,10 +58,23 @@ message: install org.deepin.calculator, version:5.7.21.4 success
 
 After the application is installed, the installation result will be displayed.
 
-The layer files we export using the `ll-builder export` command can be installed using the `ll-cli install` command.
+The layer or uab files we export using the `ll-builder export` command can be installed using the `ll-cli install` command.
 
+`.layer`
 ```bash
 ll-cli install ./com.baidu.baidunetdisk_4.17.7.0_x86_64_runtime.layer
+```
+
+`.uab`
+There are two ways to install uab files
+- use `ll-cli install` to install
+```bash
+ll-cli install com.baidu.baidunetdisk_x86_64_4.17.7.0_main.uab
+```
+
+- Install by running `.uab` directly
+```bash
+./com.baidu.baidunetdisk_x86_64_4.17.7.0_main.uab
 ```
 
 You can use the command `ll-cli list | grep com.baidu.baidunetdisk` to check if it has been installed successfully.

--- a/docs/pages/guide/ll-builder/convert.md
+++ b/docs/pages/guide/ll-builder/convert.md
@@ -37,6 +37,8 @@ Options:
   -n, --name <app description>               the description the app
   -V, --version <app version>                the version of the app
   -d, --description <app description>        detailed description of the app
+  --icon <path>                              uab icon (optional)
+  -l, --layer                                export layer file
   -o, --output <script name>                 not required option, it will
                                              generate linglong.yaml and
                                              script,you can modify
@@ -46,17 +48,20 @@ Options:
                                              .layer(.uab)
 
 Arguments:
-  convert                                    convert app with
-                                             (deb,AppImage(appimage)) format to
-                                             linglong format, you can generate
-                                             convert config file by use -o
-                                             option
+  convert                                    convert app with (deb,AppImage(appimage)) format to
+                                             linglong format, the default format is uab
+                                             if you want to export a layer file
+                                             you can use the --layer option
+                                             you can generate convert config file by use -o option
 ```
 
 `ll-builder convert` 命令会根据指定的应用名称（ `--name` 选项）生成一个目录，该目录会作为玲珑项目的根目录，即 `linglong.yaml` 文件所在的位置。它支持两种转换方法：
 
 1. 你可以使用 `--file` 选项将指定的 `appimage` 文件转换为玲珑包文件；
-2. 你可以使用 `--url` 和 `--hash` 选项将指定的 `appimage url` 和 `hash` 值转换为玲珑包文件；
+2. 你可以使用 `--url` 和 `--hash` 选项将指定的 `appimage url` 和 `hash` 值转换为玲珑包文件;
+3. 你可以使用 `--layer` 选项导出 `.layer` 格式文件，否则将默认导出 `.uab` 格式文件。
+
+`Tips: 在玲珑版本大于1.5.7时，convert 默认导出 uab 包，如果想要导出 layer 文件，需要加上 --layer 参数`
 
 你可以使用 `--output` 选项生成玲珑项目的配置文件( `linglong.yaml` )和构建玲珑 `.layer` ( `.uab` )的脚本文件
 然后你可以执行该脚本去生成对应的玲珑包当你修改 `linglong.yaml` 配置文件后。如果不指定该选项，将直接导出对应的玲珑包。
@@ -66,11 +71,32 @@ Arguments:
 指定要转换的玲珑包的相关参数，稍等片刻后你就可以得到 `io.github.brainwaves_0.15.1_x86_64_runtime.layer` 或者 `io.github.brainwaves_0.15.1_x86_64_runtime.uab` 包文件。
 
 ```bash
-ll-builder convert --url "https://github.com/makebrainwaves/BrainWaves/releases/download/v0.15.1/BrainWaves-0.15.1.AppImage" --hash "04fcfb9ccf5c0437cd3007922fdd7cd1d0a73883fd28e364b79661dbd25a4093" --name "io.github.brainwaves" --id "io.github.brainwaves" --version "0.15.1" --description "io.github.brainwaves" -v
+ll-builder convert --url "https://github.com/makebrainwaves/BrainWaves/releases/download/v0.15.1/BrainWaves-0.15.1.AppImage" --hash "04fcfb9ccf5c0437cd3007922fdd7cd1d0a73883fd28e364b79661dbd25a4093" --name "io.github.brainwaves" --id "io.github.brainwaves" --version "0.15.1" --description "io.github.brainwaves"
+```
+
+以通过 `--file` 选项将 `BrainWaves-0.15.1.AppImage` 转换为玲珑 `.uab` 为例，主要步骤如下：
+
+```bash
+ll-builder convert -f ~/Downloads/BrainWaves-0.15.1.AppImage --name "io.github.brainwaves" --id "io.github.brainwaves" --version "0.15.1" --description "io.github.brainwaves"
+```
+
+转换完成的目录结构如下:
+```text
+io.github.brainwaves
+└── io.github.brainwaves_x86_64_0.15.1.0_main.uab
 ```
 
 以通过 `--file` 选项将 `BrainWaves-0.15.1.AppImage` 转换为玲珑 `.layer` 为例，主要步骤如下：
-
 ```bash
-ll-builder convert -f ~/Downloads/BrainWaves-0.15.1.AppImage --name "io.github.brainwaves" --id "io.github.brainwaves" --version "0.15.1" --description "io.github.brainwaves" -v
+ll-builder convert -f ~/Downloads/BrainWaves-0.15.1.AppImage --name "io.github.brainwaves" --id "io.github.brainwaves" --version "0.15.1" --description "io.github.brainwaves" --layer
 ```
+
+转换完成的目录结构如下:
+```text
+io.github.brainwaves
+├── io.github.brainwaves_0.15.1.0_x86_64_binary.layer
+└── io.github.brainwaves_0.15.1.0_x86_64_develop.layer
+```
+
+`.uab` 或 `.layer` 文件验证
+导出的`.uab`或者`.layer`需要安装后进行验证，安装 layer 文件和运行应用参考：[安装应用](../ll-cli/install.md)

--- a/docs/pages/guide/ll-cli/install.md
+++ b/docs/pages/guide/ll-cli/install.md
@@ -58,10 +58,23 @@ message: install org.deepin.calculator, version:5.7.21.4 success
 
 应用安装完成后，客户端会显示安装结果信息。
 
-我们在使用 `ll-builder export` 命令导出的 layer 文件，可以使用 `ll-cli install` 进行安装。
+我们在使用 `ll-builder export` 命令导出的 layer 或者 uab 文件，可以使用 `ll-cli install` 进行安装。
 
+`.layer 文件`
 ```bash
 ll-cli install ./com.baidu.baidunetdisk_4.17.7.0_x86_64_runtime.layer
+```
+
+`.uab 文件`
+uab文件有以下两种安装方式
+- 通过 `ll-cli install` 进行安装
+```bash
+ll-cli install com.baidu.baidunetdisk_x86_64_4.17.7.0_main.uab
+```
+
+- 通过直接运行`.uab`的方式进行安装
+```bash
+./com.baidu.baidunetdisk_x86_64_4.17.7.0_main.uab
 ```
 
 可以使用 `ll-cli list | grep com.baidu.baidunetdisk` 命令来查看是否安装成功。


### PR DESCRIPTION
ll-build convert will export uab default, add --layer option to support export layer

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `--icon` and `-l, --layer` options to the `ll-builder convert` command for enhanced format export flexibility.
  - Clarified default format behavior for `.uab` and added new functionality for exporting `.layer` files.

- **Documentation**
  - Updated installation guide for `ll-cli` to include detailed instructions and examples for installing `.layer` and `.uab` files.
  - Added steps to verify successful installations and run installed applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->