### PR TITLE
fix: ll-cli upgrade error when assign version

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -748,21 +748,23 @@ auto PackageManager::Update(const QVariantMap &parameters) noexcept -> QVariantM
         return toDBusReply(paras);
     }
 
-    auto fuzzyRef = fuzzyReferenceFromPackage(paras->package);
-    if (!fuzzyRef) {
-        return toDBusReply(fuzzyRef);
+    auto installedAppFuzzyRef = package::FuzzyReference::parse(QString::fromStdString(paras->package.id));
+    if (!installedAppFuzzyRef) {
+        return toDBusReply(installedAppFuzzyRef);
     }
 
-    auto ref = this->repo.clearReference(*fuzzyRef,
+    auto ref = this->repo.clearReference(*installedAppFuzzyRef,
                                          {
                                            .fallbackToRemote = false // NOLINT
                                          });
     if (!ref) {
-        return toDBusReply(-1, fuzzyRef->toString() + " not installed.");
+        return toDBusReply(-1, installedAppFuzzyRef->toString() + " not installed.");
     }
 
-    auto fuzzyRefWithoutVersion = *fuzzyRef;
-    fuzzyRefWithoutVersion.version = std::nullopt;
+    auto fuzzyRef = fuzzyReferenceFromPackage(paras->package);
+    if (!fuzzyRef) {
+        return toDBusReply(fuzzyRef);
+    }
 
     auto newRef = this->repo.clearReference(*fuzzyRef,
                                             {


### PR DESCRIPTION
we should parse installed ref according to the package.id rather than package

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package reference handling to enhance stability and accuracy when updating installed apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->