### PR TITLE
feat: add ll-session-helper monitor listening service

### DIFF
--- a/apps/generators/90-legacy/src/main.cpp
+++ b/apps/generators/90-legacy/src/main.cpp
@@ -29,9 +29,7 @@ int main()
 
     auto &mounts = content["mounts"];
     std::multimap<std::string, std::string> roMountMap{
-        { "/etc/resolv.conf", "/run/host/etc/resolv.conf" },
         { "/etc/resolvconf", "/run/host/etc/resolvconf" },
-        { "/etc/localtime", "/run/host/etc/localtime" },
         { "/etc/machine-id", "/run/host/etc/machine-id" },
         { "/etc/machine-id", "/etc/machine-id" },
         { "/etc/ssl/certs", "/run/host/etc/ssl/certs" },
@@ -42,9 +40,7 @@ int main()
         { "/usr/share/themes", "/usr/share/themes" },
         { "/usr/share/icons", "/usr/share/icons" },
         { "/usr/share/zoneinfo", "/usr/share/zoneinfo" },
-        { "/etc/resolv.conf", "/etc/resolv.conf" },
         { "/etc/resolvconf", "/etc/resolvconf" },
-        { "/etc/localtime", "/etc/localtime" },
     };
 
     for (const auto &[source, destination] : roMountMap) {

--- a/apps/ll-session-helper/src/main.cpp
+++ b/apps/ll-session-helper/src/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
     QDir monitorPath = QStringLiteral("/run/user/") + uidString + QStringLiteral("/linglong/monitor");
 
     if (!monitorPath.exists())
-        monitorPath.mkpath(".");
+        monitorPath.mkpath(monitorPath.absolutePath());
 
     for(QString &filePath: watchFilesPaths) {
         qDebug() << QString("Add to watch: %1").arg(filePath);

--- a/debian/linglong-bin.install
+++ b/debian/linglong-bin.install
@@ -9,6 +9,7 @@ usr/lib/systemd/system-environment-generators/61-linglong
 usr/lib/systemd/system/org.deepin.linglong.PackageManager.service lib/systemd/system/
 usr/lib/systemd/user-environment-generators/61-linglong
 usr/lib/systemd/user/linglong-upgrade.service
+usr/lib/systemd/user/linglong-session-helper.service
 usr/lib/systemd/user/linglong-upgrade.timer
 usr/lib/sysusers.d/linglong.conf
 usr/libexec/linglong/00-id-mapping-static

--- a/debian/linglong-bin.postinst
+++ b/debian/linglong-bin.postinst
@@ -26,6 +26,13 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
                         # cleaned up on purge. Also remove old symlinks.
                         deb-systemd-helper --user update-state 'linglong-upgrade.service' >/dev/null || true
                 fi
+
+                deb-systemd-helper --user unmask 'linglong-session-helper.service' >/dev/null || true
+                if deb-systemd-helper --quiet --user was-enabled 'linglong-session-helper.service' ; then
+                        deb-systemd-helper --user enable 'linglong-session-helper.service' >/dev/null || true
+                else
+                        deb-systemd-helper --user update-state 'linglong-session-helper.service' >/dev/null || true
+                fi
         fi
 fi
 

--- a/libs/linglong/src/linglong/runtime/container.cpp
+++ b/libs/linglong/src/linglong/runtime/container.cpp
@@ -196,6 +196,15 @@ Container::run(const ocppi::runtime::config::types::Process &process) noexcept
       .uidMappings = {},
     });
 
+    this->cfg.mounts->push_back(ocppi::runtime::config::types::Mount{
+      .destination = "/run/host/monitor",
+      .gidMappings = {},
+      .options = { { "rbind" } },
+      .source = runtimeDir.absoluteFilePath("linglong/monitor").toStdString(),
+      .type = "bind",
+      .uidMappings = {},
+    });
+
     nlohmann::json json = this->cfg;
 
     {

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -32,6 +32,7 @@ configure_files(
   lib/systemd/system-preset/91-linglong.preset
   lib/systemd/user-environment-generators/61-linglong
   lib/systemd/user/linglong-upgrade.service
+  lib/systemd/user/linglong-session-helper.service
   lib/systemd/user/linglong-upgrade.timer
   lib/sysusers.d/linglong.conf
   script/linglong-repair-tool

--- a/misc/lib/systemd/user/linglong-session-helper.service
+++ b/misc/lib/systemd/user/linglong-session-helper.service
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+[Unit]
+Description=linglong-session-helper
+
+[Service]
+Type=simple
+ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/ll-session-helper
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
通过 ll-session-helper 服务，来监听宿主机上 /etc/resolv.conf ，/etc/localtime等文件的变化。 设置开机自启

Issue: https://github.com/linuxdeepin/developer-center/issues/8989
Log: add ll-session-helper service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `linglong-session-helper` systemd service for better session management.
  - Added `linglong-session-helper.desktop` for automatic startup configuration.

- **Improvements**
  - Enhanced directory path creation in `ll-session-helper` for reliability.
  - Improved mount configuration in container runtime for better system monitoring.

- **System Configuration**
  - Updated systemd commands in installation script to manage the new service.

- **Chores**
  - Removed unnecessary file mappings to optimize system configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->