### PR TITLE
fix 'installed wrong app when ll-cli install'

### DIFF
--- a/debian/linglong-box.install
+++ b/debian/linglong-box.install
@@ -1,2 +1,1 @@
-/usr/bin/ll-box-static
 /usr/bin/ll-box

--- a/debian/rules
+++ b/debian/rules
@@ -30,6 +30,7 @@ override_dh_auto_install:
 
 	install -d debian/linglong-builder/usr/lib/$(ARCH)/linglong/builder/uab
 	dh_install -p linglong-builder usr/lib/$(ARCH)/linglong/builder/uab/ usr/lib/$(ARCH)/linglong/builder/
+	dh_install -p linglong-box usr/bin/ll-box-static usr/bin
 endif
 
 override_dh_auto_configure:

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -279,7 +279,8 @@ utils::error::Result<QString> commitDirToRepo(GFile *dir,
         return LINGLONG_ERR("ostree_repo_prepare_transaction", gErr);
     }
 
-    transaction.addRollBack([repo, &gErr]() noexcept {
+    transaction.addRollBack([repo]() noexcept {
+        g_autoptr(GError) gErr = nullptr;
         if (ostree_repo_abort_transaction(repo, nullptr, &gErr) == FALSE) {
             qCritical() << "ostree_repo_abort_transaction:" << gErr->message << gErr->code;
         }

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -690,6 +690,10 @@ utils::error::Result<package::Reference> clearReferenceRemote(const package::Fuz
           }
 
           for (const auto &record : resp.getData()) {
+              if (fuzzy.id != record.getAppId()) {
+                  continue;
+              }
+
               auto version = package::Version::parse(record.getVersion());
               if (!version) {
                   qWarning() << "Ignore invalid package record" << record.asJson()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
    - Fixed issue with transaction rollback by removing unnecessary error reference.
    - Enhanced data processing with additional conditional checks to ensure accurate handling of records.

- **Chores**
    - Renamed executable `ll-box-static` to `ll-box` for clarity and consistency in the installation directory.
    - Updated installation rules to include the new executable name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->