### PR TITLE
fix: ll-builder push failed because of timeout

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1058,6 +1058,7 @@ utils::error::Result<void> OSTreeRepo::push(const package::Reference &ref,
         utils::error::Result<void> result;
 
         auto apiClient = this->m_clientFactory.createClient();
+        apiClient->setTimeOut(10 * 60 * 1000);
         QEventLoop loop;
         QEventLoop::connect(apiClient.data(),
                             &api::client::ClientApi::uploadTaskFileSignal,


### PR DESCRIPTION
Set interval to 10*60*1000 (10 min), default is 5 sec.

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Increased the timeout value for API client uploads to 10 minutes, enhancing stability for long-running tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->