### PR TITLE
fix: passing location of bundle directory through env

### DIFF
--- a/apps/generators/20-devices/src/main.cpp
+++ b/apps/generators/20-devices/src/main.cpp
@@ -51,7 +51,7 @@ int main()
         const auto &devPath = entry.path();
         auto devName = devPath.filename().string();
         if ((devName.rfind("video", 0) == 0) || (devName.rfind("nvidia", 0) == 0)) {
-            auto dev = u8R"(
+            auto dev = R"(
             {
                 "type": "bind",
                 "options": [ "rbind" ]

--- a/apps/generators/40-host-ipc/src/main.cpp
+++ b/apps/generators/40-host-ipc/src/main.cpp
@@ -49,7 +49,7 @@ int main()
 
     bindIfExist("/tmp/.X11-unix", "");
 
-    auto mount = u8R"({
+    auto mount = R"({
         "type": "bind",
         "options": [
             "rbind"
@@ -60,7 +60,7 @@ int main()
         auto *systemBusEnv = getenv("DBUS_SYSTEM_BUS_ADDRESS"); // NOLINT
 
         // https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-types:~:text=the%20default%20locations.-,System%20message%20bus,-A%20computer%20may
-        std::string systemBus{ u8"/var/run/dbus/system_bus_socket" };
+        std::string systemBus{ "/var/run/dbus/system_bus_socket" };
         if (systemBusEnv != nullptr && std::filesystem::exists(systemBusEnv)) {
             systemBus = systemBusEnv;
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for system calls in the `cleanAndExit` and `handleSig` functions to ensure graceful shutdown.

- **Refactor**
  - Switched from using `bundleDir` to `containerBundleDir` for directory operations, enhancing clarity and maintainability of the code.

- **Style**
  - Converted raw and Unicode string literals to regular string literals for consistency across multiple components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->