### PR TITLE
fix: linglong-session-helper can not start normal

### DIFF
--- a/misc/lib/systemd/user/linglong-session-helper.service
+++ b/misc/lib/systemd/user/linglong-session-helper.service
@@ -11,4 +11,4 @@ ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/ll-session-helper
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-users.target


### PR DESCRIPTION
WantedBy should be multi-users in systemd service

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced service management by ensuring `linglong-session-helper.service` starts automatically if inactive.

- **Improvements**
  - Changed the `WantedBy` target in `linglong-session-helper.service` for better multi-user support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->