### PR TITLE
Revert "fix: linglong-session-helper can not start normal"

### DIFF
--- a/misc/lib/systemd/user/linglong-session-helper.service
+++ b/misc/lib/systemd/user/linglong-session-helper.service
@@ -11,4 +11,4 @@ ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/ll-session-helper
 Restart=always
 
 [Install]
-WantedBy=multi-users.target
+WantedBy=multi-user.target


### PR DESCRIPTION
This reverts commit 58fa49709fd95da58458dceb0d0cb1ea6ce8545b.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the systemd service file to ensure proper operation and target detection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->