### PR TITLE
fix: linglong-session-helper.service not start when reboot

### DIFF
--- a/debian/linglong-bin.postinst
+++ b/debian/linglong-bin.postinst
@@ -39,7 +39,7 @@ configure)
         # enable kernel.unprivileged_userns_clone
         # disable kernel.apparmor_restrict_unprivileged_unconfined and kernel.apparmor_restrict_unprivileged_userns
         if [ -f /usr/lib/sysctl.d/linglong.conf ]; then
-                sysctl -p /usr/lib/sysctl.d/linglong.conf
+                sysctl -p /usr/lib/sysctl.d/linglong.conf >/dev/null || true
         fi
         ;;
 abort-upgrade | abort-remove | abort-deconfigure) ;;

--- a/misc/lib/systemd/user/linglong-session-helper.service
+++ b/misc/lib/systemd/user/linglong-session-helper.service
@@ -11,4 +11,4 @@ ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/ll-session-helper
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
linglong-session-helper.service should WantedBy default.target rather than multi-user.target

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved system configuration handling for better reliability.
	
- **Refactor**
	- Changed the service target to ensure it starts correctly with the default system targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->