### PR TITLE
fix: ll-cli run will error when layer installed

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -58,6 +58,9 @@ private:
     QVariantMap installFromUAB(const QDBusUnixFileDescriptor &fd) noexcept;
     utils::error::Result<api::types::v1::MinifiedInfo>
     updateMinifiedInfo(const QFileInfo &file, const QString &appRef, const QString &uuid) noexcept;
+    void pullDependency(InstallTask &taskContext,
+                        const api::types::v1::PackageInfoV2 &info,
+                        bool develop) noexcept;
     linglong::repo::OSTreeRepo &repo; // NOLINT
     std::vector<InstallTask> taskList;
 };


### PR DESCRIPTION
1. runtime and base should be installed when install layer
2. if app(layer) already installed, should prompt error

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of package installation, with better error messages and checks for already installed layers.
  - Enhanced dependency management for smoother installation of runtime and base dependencies.

- **Refactor**
  - Streamlined the installation process by introducing a new method to handle dependencies more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->