### PR TITLE
chore: clean package manager service file

### DIFF
--- a/misc/lib/systemd/system/org.deepin.linglong.PackageManager.service
+++ b/misc/lib/systemd/system/org.deepin.linglong.PackageManager.service
@@ -12,11 +12,6 @@ Group=@LINGLONG_USERNAME@
 BusName=org.deepin.linglong.PackageManager
 ExecStartPre=+@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/create-linglong-dirs
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/ll-package-manager
-# this opt maybe not effective, it only used to skip DBus security check, it will be removed later
-CapabilityBoundingSet=~CAP_NET_RAW
 MemoryMax=8G
 Restart=on-failure
 RestartSec=10
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
Refer to manpage of systemd.service:

> For bus-activatable services,
> do not include a [Install] section in the systemd service file,
> but use the SystemdService= option
> in the corresponding DBus service file,
> for example ...

We should not have an Install section here.

Also remove some unused capability limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed the commented-out `CapabilityBoundingSet` option from the service configuration for better clarity and maintenance.
	- Eliminated the `[Install]` section with `WantedBy=multi-user.target` from the service configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->