### PR TITLE
fix: failed to execute 'll-cli enter'

### DIFF
--- a/apps/ll-box/src/main.cpp
+++ b/apps/ll-box/src/main.cpp
@@ -183,7 +183,6 @@ int exec(struct arg_exec *arg, int argc, char **argv) noexcept
         newArgv.push_back(argv[i + 1]);
     }
 
-    newArgv.push_back("&");
     newArgv.push_back(nullptr);
 
     for (decltype(newArgv.size()) i = 0; i < newArgv.size(); ++i) {

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -304,6 +304,7 @@ int Cli::run(std::map<std::string, docopt::value> &args)
             "--login",
             "-c",
             bashArgs.join(" ").toStdString(),
+            "; wait"
         };
 
         auto opt = ocppi::runtime::ExecOption{};
@@ -435,6 +436,7 @@ int Cli::exec(std::map<std::string, docopt::value> &args)
             "--login",
             "-c",
             bashArgs.join(" ").toStdString(),
+            "; wait"
         };
     } else {
         command = { "bash", "--login" };


### PR DESCRIPTION
Remove '&' from exec() in ll-box. We add it in ll-cli. issue: https://github.com/linuxdeepin/developer-center/issues/9445

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved argument handling in the execution logic for better reliability.
  - Introduced a wait command post-execution for better control flow and timing of subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->