### PR TITLE
fix: linglong-installer show error in dock

### DIFF
--- a/apps/ll-store-installer/src/installer-dialog.cpp
+++ b/apps/ll-store-installer/src/installer-dialog.cpp
@@ -41,6 +41,7 @@ InstallerDialog::InstallerDialog(QWidget *parent)
     Q_D(InstallerDialog);
 
     setWindowTitle("Linglong Installer");
+    setWindowFlags(Qt::Dialog);
 
     auto w = new QWidget(this);
 


### PR DESCRIPTION
linglong-installer should not show in dock, so set WindowFlags to Dialog

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the installer dialog by explicitly defining its window type, improving interaction with other application windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->