### PR TITLE
chore: update docs

### DIFF
--- a/docs/pages/en/guide/ll-builder/export.md
+++ b/docs/pages/en/guide/ll-builder/export.md
@@ -4,9 +4,9 @@ SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 SPDX-License-Identifier: LGPL-3.0-or-later
 -->
 
-# Export Layer File
+# Export layer file or uab file
 
-Use `ll-builder export` to check out the build content and generate layer file.
+Use `ll-builder export` to check out the build content and generate layer file or uab file.
 
 View the help information for the `ll-builder export` command:
 
@@ -32,6 +32,8 @@ The `ll-builder export` command creates a directory named `appid` in the project
 
 An example of the `ll-builder export` command is as follows:
 
+## Export layer file
+
 ```bash
 ll-builder export --layer
 ```
@@ -44,7 +46,15 @@ The directory structure after checkout is as follows:
 linglong.yaml org.deepin.demo_0.0.0.1_x86_64_develop.layer org.deepin.demo_0.0.0.1_x86_64_runtime.layer
 ```
 
-Layer files are divided into two categories: `runtime` and `develop`. The `runtime` includes the application's execution environment, while the `develop` layer, built upon the `runtime`, retains the debugging environment.
+Layer files are divided into two categories: `binary` and `develop`. The `binary` includes the application's execution environment, while the `develop` layer, built upon the `binary`, retains the debugging environment.
+
+## Export Uab File
+
+```bash
+ll-builder export
+```
+
+The uab file is an offline distribution format used by the LingLong software package, which is not suitable for systems that can normally connect to the LingLong repository. Instead, one should utilize the delta transfer scheme provided by the LingLong software repository to reduce the network transmission size.
 
 Take the `org.deepin.demo` Linglong application as an example. The directory is as follows:
 

--- a/docs/pages/en/guide/ll-pica/convert.md
+++ b/docs/pages/en/guide/ll-pica/convert.md
@@ -17,13 +17,15 @@ Usage:
   ll-pica convert [flags]
 
 Flags:
-  -b, --build            build linglong
-  -c, --config string    config file
-  -h, --help             help for convert
-      --pi string        package id
-      --pn string        package name
-  -t, --type string      get app type (default "local")
-  -w, --workdir string   work directory
+  -b, --build               build linglong
+  -c, --config string       config file
+      --exportFile string   export uab or layer (default "uab")
+  -h, --help                help for convert
+      --pi string           package id
+      --pn string           package name
+  -t, --type string         get app type (default "local")
+      --withDep             Add dependency tree
+  -w, --workdir string      work directory
 
 Global Flags:
   -V, --verbose   verbose output
@@ -47,12 +49,13 @@ apt download com.baidu.baidunetdisk
 ```
 
 ```bash
-ll-pica convert -c com.baidu.baidunetdisk_4.17.7_amd64.deb -w w -b
+ll-pica convert -c com.baidu.baidunetdisk_4.17.7_amd64.deb -w w -b  --exportFile
 ```
 
 - -w working directory。
 - -c The configuration method employed here utilizes deb files.
 - -b It indicates that a build is required; without adding this parameter, neither building nor exporting the layer file will take place.
+- --exportFile The default export product is a uab file when using --exportFile. If you need a layer file, you should use `--exportFile layer` instead.
 
 The constructed products are as follows:
 
@@ -60,12 +63,14 @@ The constructed products are as follows:
 ├── package
 │   └── com.baidu.baidunetdisk
 │       ├── com.baidu.baidunetdisk_4.17.7.0_x86_64_develop.layer
-│       ├── com.baidu.baidunetdisk_4.17.7.0_x86_64_runtime.layer
+│       ├── com.baidu.baidunetdisk_4.17.7.0_x86_64_binary.layer
 │       ├── linglong
 │       └── linglong.yaml
 └── package.yaml
 ```
 
-Layer files are divided into two categories: `runtime` and `develop`. The `runtime` includes the application's execution environment, while the `develop` layer, built upon the `runtime`, retains the debugging environment.
+Layer files are divided into two categories: `binary` and `develop`. The `binary` includes the application's execution environment, while the `develop` layer, built upon the `binary`, retains the debugging environment.
+
+The uab file is an offline distribution format used by the LingLong software package, which is not suitable for systems that can normally connect to the LingLong repository. Instead, one should utilize the delta transfer scheme provided by the LingLong software repository to reduce the network transmission size.
 
 Installing Layer Files and Running the Application Reference：[Install Linglong Apps](../ll-cli/install.md)

--- a/docs/pages/guide/ll-builder/export.md
+++ b/docs/pages/guide/ll-builder/export.md
@@ -4,9 +4,9 @@ SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 SPDX-License-Identifier: LGPL-3.0-or-later
 -->
 
-# 导出 layer 文件
+# 导出 layer 文件 或 uab 文件
 
-`ll-builder export`命令用来检出构建内容, 生成 layer 文件。
+`ll-builder export`命令用来检出构建内容, 生成 layer 或 uab 文件。
 
 查看 `ll-builder export`命令的帮助信息：
 
@@ -28,9 +28,11 @@ Options:
   -l, --layer        export layer file
 ```
 
-`ll-builder export`命令在工程根目录下创建以 `appid`为名称的目录，并将本地构建缓存检出到该目录。同时根据该构建结果生成 layer 文件。
+`ll-builder export`命令在工程根目录下创建以 `appid` 为名称的目录，并将本地构建缓存检出到该目录。同时根据该构建结果生成 layer 文件。
 
 `ll-builder export`命令使用示例如下：
+
+## 导出 layer 文件
 
 ```bash
 ll-builder export --layer
@@ -44,7 +46,15 @@ ll-builder export --layer
 linglong.yaml org.deepin.demo_0.0.0.1_x86_64_develop.layer org.deepin.demo_0.0.0.1_x86_64_runtime.layer
 ```
 
-layer 文件分为，runtime 和 develop, runtime 包含应用的运行环境，develop 在 runtime 的基础上保留调试环境。
+layer 文件分为，binary 和 develop, binary 包含应用的运行环境，develop 在 binary 的基础上保留调试环境。
+
+## 导出 uab 文件
+
+```bash
+ll-builder export
+```
+
+uab 文件，是玲珑软件包使用的离线分发格式，并不适合可以正常连接到玲珑仓库的系统使用，应当使用玲珑软件仓库提供的增量传输方案以减少网络传输体积。
 
 以 `org.deepin.demo` 玲珑应用为例，目录如下：
 

--- a/docs/pages/guide/ll-pica/convert.md
+++ b/docs/pages/guide/ll-pica/convert.md
@@ -17,19 +17,21 @@ Usage:
   ll-pica convert [flags]
 
 Flags:
-  -b, --build            build linglong
-  -c, --config string    config file
-  -h, --help             help for convert
-      --pi string        package id
-      --pn string        package name
-  -t, --type string      get app type (default "local")
-  -w, --workdir string   work directory
+  -b, --build               build linglong
+  -c, --config string       config file
+      --exportFile string   export uab or layer (default "uab")
+  -h, --help                help for convert
+      --pi string           package id
+      --pn string           package name
+  -t, --type string         get app type (default "local")
+      --withDep             Add dependency tree
+  -w, --workdir string      work directory
 
 Global Flags:
   -V, --verbose   verbose output
 ```
 
-在执行  `ll-pica init -w w --pi com.baidu.baidunetdisk --pn com.baidu.baidunetdisk -t repo` 命令后，我们仅需要执行 `ll-pica convert -w w -b` 命令来转换出玲珑应用，这里会使用 `apt download` 命令去下载包名为 `com.baidu.baidunetdisk` 的 deb 包。
+在执行  `ll-pica init -w w --pi com.baidu.baidunetdisk --pn com.baidu.baidunetdisk -t repo` 命令后，我们仅需要执行 `ll-pica convert -w w -b --exportFile` 命令来转换出玲珑应用，这里会使用 `apt download` 命令去下载包名为 `com.baidu.baidunetdisk` 的 deb 包。
 
 :::tip
 这里使用 apt download 命令下载 deb 包，可能由于 deb 包过大而下载或者无法获取链接导致，失败推荐使用下面的命令。
@@ -42,12 +44,13 @@ apt download com.baidu.baidunetdisk
 ```
 
 ```bash
-ll-pica convert -c com.baidu.baidunetdisk_4.17.7_amd64.deb -w w -b
+ll-pica convert -c com.baidu.baidunetdisk_4.17.7_amd64.deb -w w -b --exportFile
 ```
 
 - -w 表示工作目录。
 - -c 配置的方式，这里使用 deb 文件。
 - -b 表示需要进行构建，不添加该参数不会进行构建和导出 layer 文件。
+- --exportFile 导出产物的默认为 uab 文件，如果需要 layer 文件，需要使用 --exportFile layer。
 
 构建产物如下：
 
@@ -55,12 +58,16 @@ ll-pica convert -c com.baidu.baidunetdisk_4.17.7_amd64.deb -w w -b
 ├── package
 │   └── com.baidu.baidunetdisk
 │       ├── com.baidu.baidunetdisk_4.17.7.0_x86_64_develop.layer
-│       ├── com.baidu.baidunetdisk_4.17.7.0_x86_64_runtime.layer
+│       ├── com.baidu.baidunetdisk_4.17.7.0_x86_64_binary.layer
 │       ├── linglong
 │       └── linglong.yaml
 └── package.yaml
 ```
 
-目前玲珑应用的产物是 layer 文件，layer 文件分为runtime 和 develop, runtime 包含应用的运行环境，develop 在 runtime 的基础上保留调试环境。
+玲珑应用的产物 ：
+
+layer 文件，layer 文件分为 binary 和 develop, binary 包含应用的运行环境，develop 在 binary 的基础上保留调试环境。
+
+uab 文件，是玲珑软件包使用的离线分发格式，并不适合可以正常连接到玲珑仓库的系统使用，应当使用玲珑软件仓库提供的增量传输方案以减少网络传输体积。
 
 安装 layer 文件和运行应用参考：[安装应用](../ll-cli/install.md)


### PR DESCRIPTION
更新文档中使用，ll-builder export 导出 uab 或 layer 文件的地方

Log: update docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new export option for generating uab files alongside layer files.
	- Added new command flags to the `ll-pica convert` command, enabling format specification and inclusion of a dependency tree.

- **Documentation**
	- Updated documentation terminology and structure for clarity and enhanced user guidance.
	- Added a new section explaining the purpose of uab files and provided command examples for exporting them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->