### PR TITLE
feat: add `nosymfollow` option

### DIFF
--- a/apps/ll-box/src/container/mount/host_mount.cpp
+++ b/apps/ll-box/src/container/mount/host_mount.cpp
@@ -69,6 +69,8 @@ public:
         auto dest_parent_path = util::fs::path(dest_full_path).parent_path();
         auto host_dest_full_path = driver_->HostPath(dest_full_path);
         auto root = driver_->HostPath(util::fs::path("/"));
+        int sourceFd{ -1 }; // FIXME: use local variable store fd temporarily, we should refactoring
+                            // the whole MountNode in the future
 
         switch (source_stat.st_mode & S_IFMT) {
         case S_IFCHR: {
@@ -94,7 +96,20 @@ public:
 
                 return host_dest_full_path.touch_symlink(std::string(buf.cbegin(), buf.cend()));
             }
+
             host_dest_full_path.touch();
+
+            if (m.extraFlags & OPTION_NOSYMFOLLOW) {
+                sourceFd = ::open(source.c_str(), O_PATH | O_NOFOLLOW | O_CLOEXEC);
+                if (sourceFd < 0) {
+                    logFal() << util::format("fail to open source(%s):", source.c_str())
+                             << util::errnoString();
+                }
+
+                source = util::format("/proc/self/fd/%d", sourceFd);
+                break;
+            }
+
             source = util::fs::read_symlink(util::fs::path(source)).string();
             break;
         }
@@ -230,6 +245,10 @@ public:
                 DUMP_FILE_INFO(source);
             }
             DUMP_FILE_INFO(host_dest_full_path.string());
+        }
+
+        if (sourceFd != -1) {
+            ::close(sourceFd);
         }
 
         return ret;

--- a/apps/ll-box/src/util/oci_runtime.h
+++ b/apps/ll-box/src/util/oci_runtime.h
@@ -89,7 +89,7 @@ struct Mount
     uint32_t extraFlags{ 0U };
 };
 
-enum { OPTION_COPY_SYMLINK = 1 };
+enum { OPTION_COPY_SYMLINK = 1, OPTION_NOSYMFOLLOW = 2 };
 
 inline void from_json(const nlohmann::json &j, Mount &o)
 {
@@ -131,7 +131,8 @@ inline void from_json(const nlohmann::json &j, Mount &o)
         { "norelatime", { true, MS_RELATIME } },
         { "nostrictatime", { true, MS_STRICTATIME } },
         { "nosuid", { false, MS_NOSUID } },
-        // {"nosymfollow",{false, MS_NOSYMFOLLOW}}, // since kernel 5.10
+        { "nosymfollow",
+          { false, 0, OPTION_NOSYMFOLLOW } }, // for compatibility, use custom flag for now
         { "rbind", { false, MS_BIND | MS_REC } },
         { "relatime", { false, MS_RELATIME } },
         { "remount", { false, MS_REMOUNT } },


### PR DESCRIPTION
implementation mount a fd path to destination
instead of passing the MS_NOSYMFOLLOW directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of file mounts, especially regarding symbolic links, enhancing flexibility and robustness in mounting operations.
	- Activation of the `nosymfollow` mount option allows for better management in JSON parsing during mounting.

- **Bug Fixes**
	- Resolved issues related to resource leaks by ensuring proper closure of file descriptors in mounting processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->