### PR TITLE
fix: hooks missing command args

### DIFF
--- a/misc/lib/linglong/container/config.json
+++ b/misc/lib/linglong/container/config.json
@@ -28,6 +28,7 @@
             {
                 "path": "/bin/bash",
                 "args": [
+                    "/bin/bash",
                     "-c",
                     "mkdir -p /run/linglong/etc && /sbin/ldconfig -C /run/linglong/etc/ld.so.cache"
                 ]


### PR DESCRIPTION
容器hooks缺少命令参数

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced command execution by explicitly defining the shell path, improving compatibility and clarity in execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->