### PR TITLE
fix: can not install app from store.linglong.dev

### DIFF
--- a/apps/ll-store-installer/CMakeLists.txt
+++ b/apps/ll-store-installer/CMakeLists.txt
@@ -13,7 +13,7 @@ pfl_add_executable(
   src/installer-dialog.cpp
   src/installer-dialog.h
   OUTPUT_NAME
-  ll-store-installer
+  ll-installer
   LINK_LIBRARIES
   PRIVATE
   Qt5::Widgets

--- a/debian/linglong-installer.install
+++ b/debian/linglong-installer.install
@@ -1,2 +1,2 @@
-usr/bin/ll-store-installer
+usr/bin/ll-installer
 usr/share/applications/linglong-store-installer.desktop


### PR DESCRIPTION
linglong-installer executable file name should be ll-installer

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the executable name from `ll-store-installer` to `ll-installer`, reflecting a new branding approach.
  
- **Chores**
	- Adjusted installation paths to align with the new executable naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->