### PR TITLE
Fix /var/lib/linglong is removed at boot

### DIFF
--- a/misc/lib/tmpfiles.d/linglong.conf
+++ b/misc/lib/tmpfiles.d/linglong.conf
@@ -6,4 +6,4 @@
 # at boot on systemd-based systems.
 # See tmpfiles.d(5) for details.
 
-D @CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/linglong 0755 @LINGLONG_USERNAME@ @LINGLONG_USERNAME@ -
+d @CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/linglong 0755 @LINGLONG_USERNAME@ @LINGLONG_USERNAME@ -


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Minor update in a configuration file related to systemd's tmpfiles; no impact on functionality or system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->