### PR TITLE
fix: error when pulling source code with git

### DIFF
--- a/misc/libexec/linglong/fetch-git-source
+++ b/misc/libexec/linglong/fetch-git-source
@@ -31,7 +31,7 @@ fi
 # Fetch commit
 git fetch origin "$commit" --depth 1 -n
 git add :/
-git reset --hard "$commit"
+git reset --hard FETCH_HEAD
 
 # Fetch submodule
 git submodule update --init --recursive --depth 1


### PR DESCRIPTION
如果commit填写的是tag号, 使用fetch-git-source是会报错

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Improved script behavior for fetching the latest commits from a Git repository, enhancing reliability and reducing errors related to commit references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->