### PR TITLE
fix: failed to build deb in uos i386 arch

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 include /usr/share/dpkg/pkg-info.mk
 
 OS=$(shell awk '/^NAME=/' /etc/os-release | sed 's/NAME=//' | sed 's/\"//g' | tr '[:upper:]' '[:lower:]')
-ARCH=$(shell dpkg-architecture -qDEB_TARGET_GNU_TYPE)
+ARCH=$(shell dpkg-architecture -qDEB_TARGET_MULTIARCH)
 VERSION=$(shell awk '/VERSION=/' /etc/os-release | sed 's/VERSION=//' | sed 's/\"//g' | sed 's/[.]0/./')
 ENABLE_UAB_SUPPORT=FALSE
 


### PR DESCRIPTION
use DEB_TARGET_MULTIARCH to instead of DEB_TARGET_GNU_TYPE

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved multiarch compatibility for enhanced support of different system architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->