### PR TITLE
Fix the Chinese display problem of ll-cli search

### DIFF
--- a/libs/linglong/src/linglong/cli/printer.cpp
+++ b/libs/linglong/src/linglong/cli/printer.cpp
@@ -101,29 +101,26 @@ void Printer::printPackageInfo(const api::types::v1::PackageInfoV2 &info)
         simpleDescriptionWStr = subwstr(simpleDescriptionWStr, 53) + L"...";
         simpleDescription = QString::fromStdWString(simpleDescriptionWStr);
     }
-    auto simpleDescriptionStr = simpleDescription.toStdString();
-    auto simpleDescriptionWidth = simpleDescriptionStr.size();
 
     auto id = QString::fromStdString(info.id).simplified();
+    if (id.size() > 32) {
+        id.push_back(" ");
+    }
 
     auto name = QString::fromStdString(info.name).simplified();
     auto nameWStr = name.toStdWString();
     auto nameWcswidth = wcswidth(nameWStr.c_str(), -1);
     if (nameWcswidth > 32) {
         nameWStr = subwstr(nameWStr, 29) + L"...";
+        nameWcswidth = wcswidth(nameWStr.c_str(), -1);
         name = QString::fromStdWString(nameWStr);
     }
-    if (id.size() > 32) {
-        name.push_front(" ");
-        nameWStr = name.toStdWString();
-    }
-    nameWcswidth = wcswidth(nameWStr.c_str(), -1);
     auto nameStr = name.toStdString();
     auto nameOffset = nameStr.size() - nameWcswidth;
     std::cout << std::setw(33) << id.toStdString() << std::setw(33 + nameOffset) << nameStr
               << std::setw(16) << info.version << std::setw(12) << info.arch[0] << std::setw(16)
               << info.channel << std::setw(12) << info.packageInfoV2Module
-              << std::setw(simpleDescriptionWidth) << simpleDescriptionStr << std::endl;
+              << simpleDescription.toStdString() << std::endl;
 }
 
 void Printer::printPackage(const api::types::v1::PackageInfoV2 &info)

--- a/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
@@ -24,6 +24,29 @@
 
 namespace linglong::cli::test {
 
+TEST(SubwstrTest, WithinWidthLimit) {
+    std::wstring input = L"short";
+    int width = 10;
+    std::wstring result = subwstr(input, width);
+    EXPECT_EQ(result, input);
+}
+
+TEST(SubwstrTest, TrimmedString) {
+    std::wstring input = L"this is a very long string";
+    int width = 10;
+    std::wstring expected = L"this is a ";
+    std::wstring result = subwstr(input, width);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(SubwstrTest, WideCharacters) {
+    std::wstring input = L"这是一个非常长的字符串";
+    int width = 10;
+    std::wstring expected = L"这是一个非";
+    std::wstring result = subwstr(input, width);
+    EXPECT_EQ(result, expected);
+}
+
 namespace {
 
 std::map<std::string, docopt::value> parseCommand(const QString &command)


### PR DESCRIPTION
修正ll-cli search的中文显示问题，顺便把id长度刚好为32时的id和name的不分割问题处理了：
![Screenshot_deepin-terminal](https://github.com/user-attachments/assets/745c973e-5fa4-4b1c-a0a9-37663b0cd063)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced formatting for package information displayed in the console.
	- Introduced a new helper function for managing string widths, improving output for wide characters.

- **Improvements**
	- Updated methods to better handle description, id, and name fields for improved readability and visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->