### PR TITLE
fix: app exists after the installation job canceled

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -211,6 +211,10 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd) 
           }
 
           pullDependency(taskRef, *info, isDevelop);
+          if (taskRef.currentStatus() == InstallTask::Failed
+              || taskRef.currentStatus() == InstallTask::Canceled) {
+              return;
+          }
 
           auto result = this->repo.importLayerDir(*layerDir);
           if (!result) {
@@ -662,6 +666,12 @@ void PackageManager::Install(InstallTask &taskContext,
     // for 'kind: app', check runtime and foundation
     if (info->kind == "app") {
         pullDependency(taskContext, *info, develop);
+    }
+
+    // check the status of pull runtime and foundation
+    if (taskContext.currentStatus() == InstallTask::Failed
+        || taskContext.currentStatus() == InstallTask::Canceled) {
+        return;
     }
 
     this->repo.exportReference(ref);


### PR DESCRIPTION
We should check the status of pullDependency() in package manager.

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced the Package Manager with improved error handling during package installation by providing status updates on dependency pulling operations.
  
- **Bug Fixes**
  - Resolved issues related to dependency pulling failures by implementing clear feedback mechanisms for success or failure statuses.

- **Documentation**
  - Updated documentation to reflect changes in the return types and error management processes for the Package Manager's methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->