### PR TITLE
fix: chromium timezone show error

### DIFF
--- a/apps/generators/40-host-ipc/src/main.cpp
+++ b/apps/generators/40-host-ipc/src/main.cpp
@@ -239,7 +239,6 @@ int main()
     // [name, destination, target]
     std::vector<std::array<std::string_view, 3>> vec = {
         { "ld.so.cache", "/etc/ld.so.cache", "/run/linglong/etc/ld.so.cache" },
-        { "localtime", "/etc/localtime", "/run/host/rootfs/etc/localtime" },
         { "resolv.conf", "/etc/resolv.conf", "/run/host/rootfs/etc/resolv.conf" },
         { "timezone", "/etc/timezone", "/run/host/rootfs/etc/timezone" },
     };

--- a/apps/generators/90-legacy/src/main.cpp
+++ b/apps/generators/90-legacy/src/main.cpp
@@ -28,6 +28,8 @@ int main()
     }
 
     auto &mounts = content["mounts"];
+    // FIXME: time zone in the container does not change when the host time zone changes，need to be
+    // repaired later.
     std::multimap<std::string, std::string> roMountMap{
         { "/etc/resolvconf", "/run/host/etc/resolvconf" },
         { "/etc/machine-id", "/run/host/etc/machine-id" },
@@ -41,6 +43,8 @@ int main()
         { "/usr/share/icons", "/usr/share/icons" },
         { "/usr/share/zoneinfo", "/usr/share/zoneinfo" },
         { "/etc/resolvconf", "/etc/resolvconf" },
+        { "/etc/localtime", "/run/host/etc/localtime" },
+        { "/etc/localtime", "/etc/localtime" },
     };
 
     for (const auto &[source, destination] : roMountMap) {


### PR DESCRIPTION
mount /etc/localtime directly using file instead of soft link

Log: