### PR TITLE
fix: package manager crashed

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -60,7 +60,7 @@ private:
                         const api::types::v1::PackageInfoV2 &info,
                         bool develop) noexcept;
     linglong::repo::OSTreeRepo &repo; // NOLINT
-    std::vector<InstallTask> taskList;
+    std::list<InstallTask> taskList;
 };
 
 } // namespace linglong::service


### PR DESCRIPTION
std::vector is a `Sequence containers`, references obtained from emplace_back will be dangling reference after incresing the capacity of this container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Enhanced the efficiency of installation task management within the package manager, resulting in quicker handling of tasks, especially during frequent updates.
  
- **Bug Fixes**
	- Resolved issues related to task handling that may have affected performance and reliability in previous versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->