### PR TITLE
fix(ll-box): use /proc/<pid>/stat to find the target pid

### DIFF
--- a/libs/linglong/src/linglong/package/uab_packager.cpp
+++ b/libs/linglong/src/linglong/package/uab_packager.cpp
@@ -15,7 +15,6 @@
 #include <QCryptographicHash>
 #include <QStandardPaths>
 
-#include <filesystem>
 #include <utility>
 
 #include <fcntl.h>

--- a/libs/linglong/src/linglong/package/uab_packager.h
+++ b/libs/linglong/src/linglong/package/uab_packager.h
@@ -17,6 +17,7 @@
 #include <QString>
 #include <QUuid>
 
+#include <filesystem>
 #include <unordered_set>
 
 namespace linglong::package {


### PR DESCRIPTION
compatible with linux kernel which compiled with CONFIG_PROC_CHILDREN=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced process management capabilities with new functions for retrieving parent process IDs and identifying child processes.

- **Bug Fixes**
	- Improved error handling for process ID retrieval, ensuring more robust performance in managing process relationships.

- **Refactor**
	- Streamlined existing logic for finding the last "ll-box" process, improving code readability and maintainability.
  
- **Chores**
	- Adjusted include directives to optimize dependencies related to filesystem functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->