### PR TITLE
fix: running the calendar reports a timezone error

### DIFF
--- a/apps/generators/90-legacy/src/main.cpp
+++ b/apps/generators/90-legacy/src/main.cpp
@@ -43,8 +43,6 @@ int main()
         { "/usr/share/icons", "/usr/share/icons" },
         { "/usr/share/zoneinfo", "/usr/share/zoneinfo" },
         { "/etc/resolvconf", "/etc/resolvconf" },
-        { "/etc/localtime", "/run/host/etc/localtime" },
-        { "/etc/localtime", "/etc/localtime" },
     };
 
     for (const auto &[source, destination] : roMountMap) {


### PR DESCRIPTION
localtime直接挂载成文件, 当系统是北京时区会导致日历报时间格式错误
目前定位到QDateTime.isValid返回false, 具体原因还需要后续排查

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of timezone settings within the application, ensuring accurate local time configuration in containerized environments.
	- Enhanced responsiveness to timezone changes by dynamically linking the appropriate localtime file.

- **Bug Fixes**
	- Simplified the handling of `/etc/localtime`, potentially improving overall time management by removing unnecessary mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->