### PR TITLE
fix: add validation method for layerDir

### DIFF
--- a/libs/linglong/src/linglong/package/layer_dir.cpp
+++ b/libs/linglong/src/linglong/package/layer_dir.cpp
@@ -55,4 +55,9 @@ QString LayerDir::filesDirPath() const noexcept
     return this->absoluteFilePath("files");
 }
 
+bool LayerDir::valid() const noexcept
+{
+    return this->exists("info.json");
+}
+
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/package/layer_dir.h
+++ b/libs/linglong/src/linglong/package/layer_dir.h
@@ -24,6 +24,7 @@ public:
     [[nodiscard]] bool hasMinified() const noexcept;
     [[nodiscard]] utils::error::Result<api::types::v1::MinifiedInfo> minifiedInfo() const;
     [[nodiscard]] QString filesDirPath() const noexcept;
+    [[nodiscard]] bool valid() const noexcept;
 };
 
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -140,7 +140,7 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd) 
 
     if (ref) {
         auto layerDir = this->repo.getLayerDir(*ref, isDevelop);
-        if (layerDir) {
+        if (layerDir && layerDir->valid()) {
             return toDBusReply(-1, ref->toString() + " is already installed");
         }
     }
@@ -584,7 +584,7 @@ auto PackageManager::Install(const QVariantMap &parameters) noexcept -> QVariant
 
     if (ref) {
         auto layerDir = this->repo.getLayerDir(*ref, isDevelop);
-        if (layerDir) {
+        if (layerDir && layerDir->valid()) {
             return toDBusReply(-1, ref->toString() + " is already installed");
         }
     }

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -346,7 +346,7 @@ utils::error::Result<void> handleRepositoryUpdate(OstreeRepo *repo,
         isMinified = true;
         auto newName =
           QDir::cleanPath(layerDir.absoluteFilePath(QString{ "../%1" }.arg(minifiedJson)));
-        if (!QFile::copy(newName, minified.absoluteFilePath())) {
+        if (!QFile::copy(minified.absoluteFilePath(), newName)) {
             return LINGLONG_ERR("couldn't copy minified.json to parent directory");
         }
         minified.setFile(newName);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new method to validate the presence of an "info.json" file in the `LayerDir` class, enhancing directory state checks.
- **Improvements**
	- Enhanced installation logic to include validation of the `layerDir` before processing, reducing potential installation errors.
	- Adjusted file copy operations in the repository update process to ensure correct source and destination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->